### PR TITLE
Default to v3.1.0 of the cloudformation template

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ new WafSecurityAutomations(this, 'waf-security-automations', {
 
 All are optional
 
-| Attribute         | Default    | Description                                                                                                                                       |
-| ---------         | -------    | -----------                                                                                                                                       |
-| `templateVersion` | `'latest'` | See [releases](https://github.com/awslabs/aws-waf-security-automations/releases). Best to select a version rather than using the dynamic `latest` |
+| Attribute         | Default    | Description                                                                       |
+| ---------         | -------    | -----------                                                                       |
+| `templateVersion` | `'v3.1.0'` | See [releases](https://github.com/awslabs/aws-waf-security-automations/releases). |
 
 ## Development
 

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ interface WafSecurityAutomationsOptions {
 }
 
 const optionsDefaults: WafSecurityAutomationsOptions = {
-    templateVersion: 'latest',
+    templateVersion: 'v3.1.0',
     activateSqlInjectionProtection: undefined,
     activateCrossSiteScriptingProtection: undefined,
     activateHttpFloodProtection: undefined,


### PR DESCRIPTION
Default to a fixed version, not `latest`. This also means I'm happy for the options to more tightly integrated with the template version.