### PR TITLE
More explicit option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ All are optional
 | `activateReputationListsProtection`    | `true`         | Enable to block requests from IP addresses on third-party reputation lists (supported lists: spamhaus, torproject, and emergingthreats).                              |
 | `activateBadBotProtection`             | `true`         | Enables the component designed to block bad bots and content scrapers                                                                                                 |
 | `endpointType`                         | `'cloudfront'` | Select the type of resource being used, alternative: `'alb'`                                                                                                          |
-| `errorThreshold`                       | 50             | If `activateScannersProbesProtection` is enabled, enter the maximum acceptable bad requests per minute per IP.                                                        |
-| `requestThreshold`                     | 100            | If `activateHttpFloodProtection` is enabled, enter the maximum acceptable requests per FIVE-minute period per IP address. >=100 if using WAF, >0 if Lambda or Athena. |
-| `wafBlockPeriod`                       | 240            | If `activateScannersProbesProtection` or `activateHttpFloodProtection` is enabled, enter the period (in minutes) to block applicable IP addresses.                    |
+| `errorThresholdPerMinute`              | 50             | If `activateScannersProbesProtection` is enabled, enter the maximum acceptable bad requests per minute per IP.                                                        |
+| `requestThresholdPerFiveMinutes`       | 100            | If `activateHttpFloodProtection` is enabled, enter the maximum acceptable requests per FIVE-minute period per IP address. >=100 if using WAF, >0 if Lambda or Athena. |
+| `wafBlockPeriodMinutes`                | 240            | If `activateScannersProbesProtection` or `activateHttpFloodProtection` is enabled, enter the period (in minutes) to block applicable IP addresses.                    |
 | `keepDataInOriginalS3Location`         | `false`        | By default log files will be moved from their original location to a partitioned folder structure in s3. Set to `true` to copy instead.                               |
 
 ## Development

--- a/index.ts
+++ b/index.ts
@@ -18,9 +18,9 @@ interface WafSecurityAutomationsOptions {
     readonly activateReputationListsProtection: boolean | undefined;
     readonly activateBadBotProtection: boolean | undefined;
     readonly endpointType: 'cloudfront' | 'alb' | undefined;
-    readonly requestThreshold: number | undefined;
-    readonly errorThreshold: number | undefined;
-    readonly wafBlockPeriod: number | undefined;
+    readonly requestThresholdPerFiveMinutes: number | undefined;
+    readonly errorThresholdPerMinute: number | undefined;
+    readonly wafBlockPeriodMinutes: number | undefined;
     readonly keepDataInOriginalS3Location: boolean | undefined;
 }
 
@@ -35,9 +35,9 @@ const optionsDefaults: WafSecurityAutomationsOptions = {
     activateReputationListsProtection: true,
     activateBadBotProtection: true,
     endpointType: 'cloudfront',
-    requestThreshold: 100,
-    errorThreshold: 50,
-    wafBlockPeriod: 240,
+    requestThresholdPerFiveMinutes: 100,
+    errorThresholdPerMinute: 50,
+    wafBlockPeriodMinutes: 240,
     keepDataInOriginalS3Location: false,
 };
 

--- a/provider/index.ts
+++ b/provider/index.ts
@@ -155,9 +155,9 @@ const loadParametersFromOptions = (optionsJson: unknown): Array<CloudformationPa
         createParameter('ActivateReputationListsProtectionParam', simpleBooleanValue(options.activateReputationListsProtection)),
         createParameter('ActivateBadBotProtectionParam', simpleBooleanValue(options.activateBadBotProtection)),
         createParameter('EndpointType', endpointTypeValue(options.endpointType)),
-        createParameter('ErrorThreshold', numberValue(options.errorThreshold)),
-        createParameter('RequestThreshold', numberValue(options.requestThreshold)),
-        createParameter('WAFBlockPeriod', numberValue(options.wafBlockPeriod)),
+        createParameter('ErrorThreshold', numberValue(options.errorThresholdPerMinute)),
+        createParameter('RequestThreshold', numberValue(options.requestThresholdPerFiveMinutes)),
+        createParameter('WAFBlockPeriod', numberValue(options.wafBlockPeriodMinutes)),
         createParameter('KeepDataInOriginalS3Location', simpleBooleanValueCapitalised(options.keepDataInOriginalS3Location)),
     ];
 


### PR DESCRIPTION
There are a few surprises in how the values for the options are used (one rate is per minute, another is per 5-minutes). This makes them explicit.