### PR TITLE
Retrieve attributes from created webACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,19 @@
 ## Usage
 
 ```typescript
-new WafSecurityAutomations(this, 'waf-security-automations', {
+const wafAutomations = new WafSecurityAutomations(this, 'waf-security-automations', {
     stackName: 'waf-security-automations',
     accessLogBucket: myLogBucket,
     options: {
         // See below
     },
 });
+
+// Can now use the following:
+wafAutomations.webAclName  // string, the name of the created webAcl, will match stackName due to implementation of the cfn template
+wafAutomations.webAclArn  // string, arn of the created webAcl, pass this to a Cloudfront distribution
+wafAutomations.webAclId   // string
+wafAutomations.webAclDescription  // string
 ```
 
 This creates a WAFv2 WebACL named matching the `stackName`.

--- a/index.ts
+++ b/index.ts
@@ -51,6 +51,10 @@ export class WafSecurityAutomations extends cdk.Construct {
     public readonly accessLogBucket: s3.IBucket;
     public readonly stackName: string;
     public readonly resource: cdk.CustomResource;
+    public readonly webAclName: string;
+    public readonly webAclArn: string;
+    public readonly webAclId: string;
+    public readonly webAclDescription: string;
 
     constructor(scope: cdk.Construct, id: string, props: WafSecurityAutomationsProps) {
         super(scope, id);
@@ -101,5 +105,10 @@ export class WafSecurityAutomations extends cdk.Construct {
                 Options: JSON.stringify(options),
             },
         });
+
+        this.webAclName = this.resource.getAttString('WebAclName');
+        this.webAclArn = this.resource.getAttString('WebAclArn');
+        this.webAclId = this.resource.getAttString('WebAclId');
+        this.webAclDescription = this.resource.getAttString('WebAclDescription');
     }
 }


### PR DESCRIPTION
Crucially, this finds the ARN of the created WAF WebACL, which is what you need to pass to a Cloudfront distribution.