### PR TITLE
Change index exports to cdkv2

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export * from './cdkv1';
+export * from './cdkv2';


### PR DESCRIPTION
CDK v1 is going EOL. Retaining the old code for now because it does still work.

Required changes:
- If you are using CDK v1, you _must_ change imports:
    - from: `import { WafSecurityAutomations } from 'waf-automations-cdk'`
    - to: `import { WafSecurityAutomations } from 'waf-automations-cdk/cdkv1'`

Recommended changes:
- If you are using CDK v2, you should change imports (not required yet, but will become mandatory in a future major release)
    - from: `import { WafSecurityAutomations } from 'waf-automations-cdk/cdkv2'`
    - to: `import { WafSecurityAutomations } from 'waf-automations-cdk'`