### PR TITLE
Remove deprecated "main" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "waf-automations-cdk",
   "version": "3.0.1",
   "description": "Deploy the AWS WAF Automations",
-  "main": "build/index.js",
   "peerDependencies": {
     "@aws-cdk/aws-iam": "^1.89.0",
     "@aws-cdk/aws-lambda": "^1.89.0",


### PR DESCRIPTION
To remove warnings like:
```
[DEP0128] DeprecationWarning: Invalid 'main' field in '/.../node_modules/waf-automations-cdk/package.json' of 'build/index.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```